### PR TITLE
Increase the debounce time

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -7,7 +7,7 @@
 #define FRAMES_PER_SECOND 60
 
 /* Millisecons to wait for debouncing keypresses */
-#define DEBOUNCE_WAIT 100
+#define DEBOUNCE_WAIT 250
 
 #define MAX_TEXT_BUFF_SIZE 100
 


### PR DESCRIPTION
Update the debounce wait variable to avoid having the cursor jump around in the main menu.